### PR TITLE
Forgot to remove the nullable column on the foreign key id.

### DIFF
--- a/database/migrations/2025_10_05_200140_create_squawks_table.php
+++ b/database/migrations/2025_10_05_200140_create_squawks_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('squawks', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->nullable()->constrained('users')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
             $table->string('message', 500);
             $table->timestamps();
         });


### PR DESCRIPTION
This was meant to have been fixed ie removed from the migration as the authentication methodology was added so users could be created and logged in via the user interface.  so the nullable is now removed,